### PR TITLE
Add support for CPDLC messages

### DIFF
--- a/src/hoppie_connector/CPDLC.py
+++ b/src/hoppie_connector/CPDLC.py
@@ -1,0 +1,12 @@
+from enum import StrEnum
+
+class CpdlcResponseRequirement(StrEnum):
+    WILCO_UNABLE    = W_U = 'WU'
+    AFFIRM_NEGATIVE = A_N = 'AN'
+    ROGER           = R = 'R'
+    NOT_REQUIRED    = NE = 'NE'
+    NO              = N = 'N'
+    YES             = Y = 'Y'
+
+    def __repr__(self) -> str:
+        return f"CpdlcResponseRequirement.{self.name}"

--- a/src/hoppie_connector/__init__.py
+++ b/src/hoppie_connector/__init__.py
@@ -203,6 +203,6 @@ class HoppieConnector(object):
             mrn (int | None, optional): Message Reference Number. Defaults to None.
 
         Returns:
-            timedelta: _description_
+            timedelta: Response delay
         """
         return self._connect(CpdlcMessage(self._station, to_name, min, rr, message, mrn), SuccessResponse)[1]

--- a/src/hoppie_connector/__init__.py
+++ b/src/hoppie_connector/__init__.py
@@ -1,6 +1,7 @@
-from .Messages import HoppieMessage, ProgressMessage, PeekMessage, PollMessage, PingMessage, TelexMessage, AdscPeriodicContractRequestMessage, AdscContractCancellationMessage, AdscContractRejectionMessage, AdscPeriodicReportMessage, HoppieMessageParser
+from .Messages import HoppieMessage, ProgressMessage, PeekMessage, PollMessage, PingMessage, TelexMessage, AdscPeriodicContractRequestMessage, AdscContractCancellationMessage, AdscContractRejectionMessage, AdscPeriodicReportMessage, CpdlcMessage, HoppieMessageParser
 from .Responses import ErrorResponse, SuccessResponse, PollSuccessResponse, PingSuccessResponse, PeekSuccessResponse
 from .ADSC import AdscData
+from .CPDLC import CpdlcResponseRequirement
 from .API import HoppieAPI
 from datetime import timedelta, time
 from typing import TypeVar
@@ -186,3 +187,22 @@ class HoppieConnector(object):
             timedelta: Response delay
         """
         return self._connect(AdscContractRejectionMessage(self._station, to_name), SuccessResponse)[1]
+
+    def send_cpdlc(self, to_name: str, min: int, rr: CpdlcResponseRequirement, message: str, mrn: int | None = None) -> timedelta:
+        """Send a CPDLC message to recipient station
+
+        Note:
+            Special restrictions regarding polling interval apply for airborne stations. See hoppie.nl docs.
+            See CPDLC docs for further information about how to populate the data fields below.
+
+        Args:
+            to_name (str): Recipient station name
+            min (int): Message Identification Number
+            rr (CpdlcResponseRequirement): Response Requirement
+            message (str): Message element
+            mrn (int | None, optional): Message Reference Number. Defaults to None.
+
+        Returns:
+            timedelta: _description_
+        """
+        return self._connect(CpdlcMessage(self._station, to_name, min, rr, message, mrn), SuccessResponse)[1]

--- a/tests/test_CpdlcMessage.py
+++ b/tests/test_CpdlcMessage.py
@@ -1,0 +1,63 @@
+from hoppie_connector.Messages import CpdlcMessage, HoppieMessage, HoppieMessage as Super
+from hoppie_connector.CPDLC import CpdlcResponseRequirement as RR
+import unittest
+
+class TestCpdlcMessage(unittest.TestCase):
+    _EXPECTED_TYPE: HoppieMessage.MessageType = HoppieMessage.MessageType.CPDLC
+    _EXPECTED_MIN: int = 1
+    _EXPECTED_RR: RR = RR.NE
+    _EXPECTED_MESSAGE: str = 'DEPART REQUEST STATUS . FSM 1957 240826 ENGM @SAS385@ RCD RECEIVED @REQUEST BEING PROCESSED @STANDBY'
+    _EXPECTED_PACKET: str = '/data2/1//NE/DEPART REQUEST STATUS . FSM 1957 240826 ENGM @SAS385@ RCD RECEIVED @REQUEST BEING PROCESSED @STANDBY'
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._UUT = CpdlcMessage('ATSU', 'CALLSIGN', self._EXPECTED_MIN, self._EXPECTED_RR, self._EXPECTED_MESSAGE)
+
+    def test_get_msg_type(self):       self.assertEqual(self._EXPECTED_TYPE,    self._UUT.get_msg_type())
+    def test_get_min(self):            self.assertEqual(self._EXPECTED_MIN,     self._UUT.get_min())
+    def test_get_rr(self):             self.assertEqual(self._EXPECTED_RR,      self._UUT.get_rr())
+    def test_get_message(self):        self.assertEqual(self._EXPECTED_MESSAGE, self._UUT.get_message())
+    def test_get_mrn(self):            self.assertIsNone(self._UUT.get_mrn())
+    def test_get_packet_content(self): self.assertEqual(self._EXPECTED_PACKET,  self._UUT.get_packet_content())
+    def test_hierarchy_super(self):    self.assertIsInstance(self._UUT, Super)
+
+class TestCpdlcMessageWithMRN(unittest.TestCase):
+    _EXPECTED_MRN: int = 19
+    _EXPECTED_PACKET: str = '/data2/6/19/N/WILCO'
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._UUT = CpdlcMessage('CALLSIGN', 'ATSU', 6, RR.N, 'WILCO', self._EXPECTED_MRN)
+
+    def test_get_mrn(self):            self.assertEqual(self._EXPECTED_MRN, self._UUT.get_mrn())
+    def test_get_packet_content(self): self.assertEqual(self._EXPECTED_PACKET,  self._UUT.get_packet_content())
+
+class TestCpdlcMessageRepresentation(unittest.TestCase):
+    def test_repr(self):
+        from hoppie_connector.CPDLC import CpdlcResponseRequirement # used inside eval()
+
+        expected = CpdlcMessage('ATSU', 'CALLSIGN', 1, RR.NE, 'TEST MSG')
+        actual = eval(repr(expected))
+        self.assertEqual(expected, actual)
+
+    def test_repr_mrn(self):
+        from hoppie_connector.CPDLC import CpdlcResponseRequirement # used inside eval()
+        
+        expected = CpdlcMessage('ATSU', 'CALLSIGN', 1, RR.Y, 'TEST MSG', 12)
+        actual = eval(repr(expected))
+        self.assertEqual(expected, actual)
+
+class TestCpdlcMessageInputValidation(unittest.TestCase):
+    def test_invalid_min(self): self.assertRaises(ValueError, lambda: CpdlcMessage('CALLSIGN', 'ATSU', -1, RR.A_N, 'MSG'))
+    def test_invalid_mrn(self): self.assertRaises(ValueError, lambda: CpdlcMessage('CALLSIGN', 'ATSU', 1, RR.A_N, 'MSG', -1))
+    def test_invalid_msg(self): self.assertRaises(ValueError, lambda: CpdlcMessage('CALLSIGN', 'ATSU', 1, RR.A_N, 'UNSUPPORTED / CHAR'))
+    def test_invalid_rr(self):  self.assertRaises(ValueError, lambda: CpdlcMessage('CALLSIGN', 'ATSU', 1, 'INVALID', 'MSG'))
+
+class TestCpdlcMessageFromPacket(unittest.TestCase):
+    def test_valid(self):
+        expected = CpdlcMessage('CALLSIGN', 'ATSU', 1, RR.AFFIRM_NEGATIVE, 'MESSAGE STR')
+        actual = CpdlcMessage.from_packet('CALLSIGN', 'ATSU', '/data2/1//AN/MESSAGE STR')
+        self.assertEqual(expected, actual)
+
+    def test_malformed(self):
+        self.assertRaises(ValueError, lambda: CpdlcMessage.from_packet('CALLSIGN', 'ATSU', '//1/N/WILCO'))

--- a/tests/test_CpdlcResponseRequirement.py
+++ b/tests/test_CpdlcResponseRequirement.py
@@ -1,0 +1,39 @@
+from hoppie_connector.CPDLC import CpdlcResponseRequirement
+import unittest
+
+class TestCpdlcResponseRequirement(unittest.TestCase):
+    def test_wilco_unable(self):
+        expected = 'WU'
+        self.assertEqual(expected, CpdlcResponseRequirement.WILCO_UNABLE)
+        self.assertEqual(expected, CpdlcResponseRequirement.W_U)
+
+    def test_affirm_negative(self):
+        expected = 'AN'
+        self.assertEqual(expected, CpdlcResponseRequirement.AFFIRM_NEGATIVE)
+        self.assertEqual(expected, CpdlcResponseRequirement.A_N)
+
+    def test_roger(self):
+        expected='R'
+        self.assertEqual(expected, CpdlcResponseRequirement.ROGER)
+        self.assertEqual(expected, CpdlcResponseRequirement.R)
+
+    def test_not_required(self):
+        expected='NE'
+        self.assertEqual(expected, CpdlcResponseRequirement.NE)
+        self.assertEqual(expected, CpdlcResponseRequirement.NOT_REQUIRED)
+
+    def test_no(self):
+        expected='N'
+        self.assertEqual(expected, CpdlcResponseRequirement.NO)
+        self.assertEqual(expected, CpdlcResponseRequirement.N)
+
+    def test_yes(self):
+        expected='Y'
+        self.assertEqual(expected, CpdlcResponseRequirement.YES)
+        self.assertEqual(expected, CpdlcResponseRequirement.Y)
+
+class TestCpdlcResponseRequirementRepresentation(unittest.TestCase):
+    def test_repr(self):
+        expected = CpdlcResponseRequirement.WILCO_UNABLE
+        actual = eval(repr(expected))
+        self.assertEqual(expected, actual)

--- a/tests/test_HoppieConnector.py
+++ b/tests/test_HoppieConnector.py
@@ -2,6 +2,7 @@ from hoppie_connector import HoppieConnector, HoppieError, HoppieWarning
 from hoppie_connector.Messages import TelexMessage
 from hoppie_connector.Responses import PingSuccessResponse
 from hoppie_connector.ADSC import AdscData, BasicGroup, FlightIdentGroup
+from hoppie_connector.CPDLC import CpdlcResponseRequirement
 from responses import matchers
 from datetime import timedelta, time, datetime
 import responses
@@ -106,6 +107,15 @@ class TestHoppieConnectorSuccess(unittest.TestCase):
         ])
 
         actual = HoppieConnector(self._STATION, self._LOGON, self._URL).send_adsc_reject('ATC')
+        self.assertGreater(actual, timedelta(0))
+
+    @responses.activate
+    def tests_send_cpdlc(self):
+        responses.get(self._URL, body='ok', match=[
+            matchers.query_param_matcher({'logon': self._LOGON, 'from': self._STATION, 'to': 'ATSU', 'type': 'cpdlc', 'packet': '/data2/1//N/TEST'})
+        ])
+        
+        actual = HoppieConnector(self._STATION, self._LOGON, self._URL).send_cpdlc('ATSU', 1, CpdlcResponseRequirement.N, 'TEST')
         self.assertGreater(actual, timedelta(0))
 
     @responses.activate

--- a/tests/test_HoppieMessageParser.py
+++ b/tests/test_HoppieMessageParser.py
@@ -1,4 +1,4 @@
-from hoppie_connector.Messages import PeekMessage, PollMessage, TelexMessage, ProgressMessage, PingMessage, AdscPeriodicReportMessage, HoppieMessageParser
+from hoppie_connector.Messages import TelexMessage, ProgressMessage, AdscPeriodicReportMessage, CpdlcMessage, HoppieMessageParser
 from datetime import datetime, UTC
 import unittest
 
@@ -16,6 +16,9 @@ class TestHoppieMessageParser(unittest.TestCase):
     def test_parse_adsc(self):
         actual = self._UUT.parse({'from': 'CALLSIGN', 'type': 'ads-c', 'packet': 'REPORT CALLSIGN 011820 0.000000 0.000000 0'})
         self.assertIsInstance(actual, AdscPeriodicReportMessage)
+    def test_parse_cpdlc(self):
+        actual = self._UUT.parse({'from': 'CALLSIGN', 'type': 'cpdlc', 'packet': '/data2/1/2/N/WILCO'})
+        self.assertIsInstance(actual, CpdlcMessage)
 
 class TestHoppieMessageParserErrorHandling(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
### Summary

This PR contains additions to enable CPDLC message handling. 

### Description

CPDLC messages are represented by fixed-format text messages using the `cpdlc` message type, and consisting of (in this order) a fixed exchange format identifier, a message identification number, a message reference number, a response requirement specifier, and aplain-text message element:

    /data2/5/14/N/WILCO

For initial messages, the referenced message ID field is left blank:

    /data2/1//WU/CLD TO @KJFK@. @TRUKN2@ DEPARTURE. MN...

The message element may only contain uppercase characters, numbers 0 through 9, spaces, and the following special characters:

* `@` (at) used as a field delimiter
* `_` (underscore) used as a field delimiter
* `.` (decimal point) used as a field delimiter and decimal point for radio frequencies

Processing of data fields embedded in the message element is left to the application. Additional restrictions in regard to the maximum allowed polling rate apply, depending on the application usecase (airborne or ground station).

### References

* [Reverse engineering by @robin24](https://github.com/islandcontroller/hoppie-connector/issues/1#issuecomment-2310740181)
* [CPDLC format documentation by @devHazz](https://github.com/devHazz/hoppie-acars-docs/blob/main/Messaging/CPDLC%20Format.md)
* [Hoppie's CPDLC documentation](https://web.archive.org/web/20240419192409/https://www.hoppie.nl/acars/system/cpdlc.html) (Archived)
* [*Guidance Material for ATS Data Link Services in NAT Airspace, Chapter 2 - CPDLC*, NAVCANADA, Version 10.0, May 20th, 2004](https://web.archive.org/web/20240718163306/https://www.notams.faa.gov/downloads/CPDLC_ver_10.pdf) (Archived)

### Change summary

- Adds `CpdlcMessage` subclass using `cpdlc` message type
- Adds `CPDLC` submodule containing supporting classes for CPDLC message handling (namely, an enum of valid Response Requirement types)
- Adds `HoppieMessageParser` functionality to cover `cpdlc` message types
- Adds `send_cpdlc` interface function to `HoppieConnector`
- Adds new test cases to regain 100% coverage
- Resolves #1